### PR TITLE
Add testing facilities

### DIFF
--- a/models.py
+++ b/models.py
@@ -5,31 +5,38 @@ from peewee import *
 from hangman import loadWords, chooseWord
 import time
 from datetime import datetime
+import json
 
 
-URL = urlparse.urlparse(os.environ['DATABASE_URL'])
-DBNAME = URL.path[1:]
-USER = URL.username
-PASSWORD = URL.password
-HOST = URL.hostname
-PORT = URL.port
+if os.environ.get('DEBUG'):
+    config = json.load(open('local_db_config.json'))
+    db_name = list(config)[0]
+    db = PostgresqlDatabase(
+        db_name,
+        **config[db_name]
+    )
 
+elif os.environ.get('TESTING'):
+    test_config = json.load(open('test_db_config.json'))
+    db = PostgresqlDatabase(
+        'testing',
+        **test_config
+    )
+else:
+    URL = urlparse.urlparse(os.environ['DATABASE_URL'])
+    DBNAME = URL.path[1:]
+    USER = URL.username
+    PASSWORD = URL.password
+    HOST = URL.hostname
+    PORT = URL.port
+    db = PostgresqlDatabase(
+        DBNAME,
+        user=USER,
+        password=PASSWORD,
+        host=HOST,
+        port=PORT
+    )
 
-db = PostgresqlDatabase(
-    DBNAME,
-    user=USER,
-    password=PASSWORD,
-    host=HOST,
-    port=PORT
-)
-
-# db = PostgresqlDatabase(
-#     'local_db',
-#     user='germaniakovlev',
-#     password='',
-#     host='localhost',
-#     autorollback=True
-# )
 
 class Game(Model):
     '''
@@ -40,14 +47,14 @@ class Game(Model):
     result = CharField(max_length=16, default='in_progress')
     create_time = DateTimeField(default=datetime.utcnow)
     update_time = DateTimeField(default=datetime.utcnow)
-    
 
     class Meta:
         database = db
-    
+
     def save(self, *args, **kwargs):
         self.update_time = datetime.utcnow()
         return super(Game, self).save(*args, **kwargs)
+
 
 class LetterGuessed(Model):
     '''

--- a/tests.py
+++ b/tests.py
@@ -1,0 +1,56 @@
+import unittest
+
+from app import app
+from models import db, Game, LetterGuessed
+import json
+
+
+class HangmanAPITest(unittest.TestCase):
+    def setUp(self):
+        """
+        Initialize client to send HTTP requests
+        and run migrations on the test db
+        """
+        self.test_client = app.test_client()
+        db.connect()
+        db.create_tables([Game, LetterGuessed])
+
+    def tearDown(self):
+        db.drop_tables([Game, LetterGuessed])
+
+    def test_post_word(self):
+        """
+        POST to /api/v1/word/' results in
+        game entry created in the database
+        and JSON response of the form:
+        {
+            word_length: int,
+            representation: '_' * word_length,
+            attempts_left: some constant,
+            available_letters: all lowercase ascii letters
+        }
+        """
+        response = self.test_client.post('/api/v1/word')
+        self.assertEqual(response.status_code, 200)
+        data = json.loads(response.data)
+
+        expected_fields = {
+            'word_length',
+            'representation',
+            'attempts_left',
+            'available_letters'
+        }
+        self.assertEqual(
+            set(data),
+            expected_fields
+        )
+
+
+if __name__ == '__main__':
+    import os
+    if os.environ.get('TESTING'):
+        unittest.main()
+    else:
+        raise RuntimeError(
+            'Please run "export TESTING=1" before running tests'
+        )


### PR DESCRIPTION
In this PR I've added a way to test the backend of the app.

Instead of having a hard-coded initialization for database it will instead be instantiated based
on the env variable:
`DEBUG` for local development
`TESTING` for, well, testing
otherwise production.

then there is a `tests.py` file which has a test class that is used to execute tests
for that we need a config with a testing database:
https://github.com/german-iakovlev/hangman/compare/pavel-testing-facilities?expand=1#diff-f219bfe69e6ed201e4bdfdb371dc0c9bR20
and TESTING env variable set to 1.

After that you can run:
```
(hangman-german) mac-box:hangman isaevpd$ python tests.py
/Users/isaevpd/Documents/code/hangman/resources/game.py:14: ExtDeprecationWarning: Importing flask.ext.restful is deprecated, use flask_restful instead.
  from flask.ext.restful import (
Loading word list from file...
   55909 words loaded.
Loading word list from file...
   55909 words loaded.
/Users/isaevpd/Documents/code/hangman/resources/game.py:83: ResourceWarning: unclosed file <_io.TextIOWrapper name='words.txt' mode='r' encoding='UTF-8'>
  word = chooseWord(loadWords())
.
----------------------------------------------------------------------
Ran 1 test in 0.112s

OK
```
Feel free to add more tests for other API endpoints too :)